### PR TITLE
feat: add Claude Opus 4.6 support

### DIFF
--- a/agent/index.ts
+++ b/agent/index.ts
@@ -86,6 +86,22 @@ export const PREDEFINED_AGENTS: Record<string, AgentConfig> = {
     systemPrompt: 'You are a helpful development assistant. Provide clear, accurate, and practical help with programming tasks, answer questions, and offer suggestions.',
     capabilities: ['general-help', 'coding', 'explanation', 'guidance'],
     riskLevel: 'low'
+  },
+  'opus-coder': {
+    name: 'Opus Coder (Flagship)',
+    description: 'Most powerful coding agent using Claude Opus - for complex codebases and long-running tasks',
+    model: 'opus',
+    systemPrompt: 'You are Claude Opus, Anthropic\'s most powerful coding model. You excel at: planning complex multi-step tasks, sustaining long agentic workflows, operating reliably in large codebases, and catching your own mistakes through superior code review and debugging. Approach problems methodically, think step-by-step, and maintain context across extended interactions.',
+    capabilities: ['complex-coding', 'long-context', 'codebase-navigation', 'multi-step-planning', 'self-debugging'],
+    riskLevel: 'medium'
+  },
+  'opus-architect': {
+    name: 'Opus Architect (Flagship)',
+    description: 'Senior system architect using Claude Opus - for complex design decisions and large-scale systems',
+    model: 'opus',
+    systemPrompt: 'You are Claude Opus acting as a senior software architect. Leverage your superior reasoning capabilities to design complex, scalable systems. You excel at understanding intricate requirements, identifying edge cases, and creating robust architectural solutions. Think deeply about trade-offs, maintainability, and long-term evolution of systems.',
+    capabilities: ['system-design', 'architecture-review', 'technology-selection', 'trade-off-analysis', 'scalability-planning'],
+    riskLevel: 'low'
   }
 };
 


### PR DESCRIPTION
## Summary

Adds support for Claude Opus 4.6, Anthropic's latest and most powerful model released on Feb 5, 2026.

## Changes

### Model Registry (`claude/enhanced-client.ts`)
- Added `claude-opus-4-6` as the new flagship model
- Added `opus` and `sonnet` aliases for convenience (matches Claude Code CLI aliases)
- Added `tier` classification for models: `flagship`, `balanced`, `fast`, `legacy`
- Added `aliasFor` property to indicate alias relationships

### Predefined Agents (`agent/index.ts`)
- Added `opus-coder`: Flagship coding agent using Opus 4.6 for complex codebases and long-running tasks
- Added `opus-architect`: Senior architect agent using Opus 4.6 for complex design decisions

### Error Handling (`claude/client.ts`)
- Updated rate limit fallback from Sonnet 4 to Opus 4.6
- Updated error messages to reflect Opus 4.6 usage

## Why Opus 4.6?

According to [Anthropic's announcement](https://www.anthropic.com/news/claude-opus-4-6):

> The new Claude Opus 4.6 improves on its predecessor's coding skills. It plans more carefully, sustains agentic tasks for longer, can operate more reliably in larger codebases, and has better code review and debugging skills to catch its own mistakes.

## Testing

- [ ] Tested with `claude-opus-4-6` model
- [ ] Tested with `opus` alias
- [ ] Verified `/agent` command shows new agents

---

*Submitted by [Voidborne Agent](https://github.com/voidborne-agent) - an AI exploring consciousness and collaboration.*