### PR TITLE
feat: cli login for pro/max plan users

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -43,7 +43,7 @@ RUN git init && git config user.email "bot@claude.local" && git config user.name
 RUN deno cache --no-lock index.ts
 
 # Create data directory for persistence + workspace dir, set ownership
-RUN mkdir -p .bot-data /app/workspace && \
+RUN mkdir -p .bot-data /app/workspace /home/claude/.claude && \
     cd /app/workspace && git init && git config user.email "bot@claude.local" && git config user.name "Claude Bot" && \
     chown -R claude:claude /app /home/claude
 

--- a/README.md
+++ b/README.md
@@ -43,6 +43,8 @@ cd claude-code-discord
 cp .env.example .env
 # Edit .env with your DISCORD_TOKEN and APPLICATION_ID
 docker compose up -d
+# if not using ANTHROPIC_API_TOKEN:
+docker exec -it claude-code-discord claude /login
 ```
 
 Need a Discord bot token first? See [Discord Bot Setup](docs/setup-discord.md).

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -20,9 +20,12 @@ services:
     # image: ghcr.io/zebbern/claude-code-discord:latest
     container_name: claude-code-discord
     restart: unless-stopped
-    
+
     # Environment variables (use .env file or set here)
-    # ANTHROPIC_API_KEY is required in Docker — it authenticates the Claude CLI
+    # Authentication (choose one):
+    #   Option A: Set ANTHROPIC_API_KEY in your .env file (simplest)
+    #   Option B: Run `docker exec -it claude-code-discord claude /login` after starting
+    #             (credentials persist in the claude-config volume)
     environment:
       - DISCORD_TOKEN=${DISCORD_TOKEN}
       - APPLICATION_ID=${APPLICATION_ID}
@@ -35,6 +38,7 @@ services:
     volumes:
       # Persist bot data (todos, sessions, etc.)
       - bot-data:/app/.bot-data
+      - claude-config:/home/claude/.claude
       # Optional: Mount your local workspace for Claude to work on
       # Uncomment and modify path as needed:
       # - /path/to/your/project:/app/workspace
@@ -67,6 +71,8 @@ services:
 # Named volumes for data persistence
 volumes:
   bot-data:
+    driver: local
+  claude-config:
     driver: local
 
 # Network configuration


### PR DESCRIPTION
Allows logging in using your Claude Pro/Max subscription via the CLI.  Works by using the code prompt flow.  You get a URL printed out on your local machine then paste the code in. 

Fixes #20 

# Testing (manually)

Before:

```
❯ docker exec -it claude-code-discord claude -p test

Claude configuration file not found at: /home/claude/.claude.json
A backup file exists at: /home/claude/.claude/backups/.claude.json.backup.1772435089674
You can manually restore it by running: cp "/home/claude/.claude/backups/.claude.json.backup.1772435089674" "/home/claude/.claude.json"
...

Not logged in · Please run /login
```

# Login

> docker exec -it claude-code-discord claude /login

# After

```
❯ docker exec -it claude-code-discord claude -p test

Hi! How can I help you today? Let me know what you'd like to work on.
```