### PR TITLE
feat: free-form message handling in bot channel/threads

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -27,6 +27,28 @@ APPLICATION_ID=your_application_id_here
 ANTHROPIC_API_KEY=your_anthropic_api_key_here
 
 # ===================================
+# AWS BEDROCK BACKEND (optional)
+# ===================================
+# Set CLAUDE_CODE_USE_BEDROCK=1 to route LLM calls through AWS Bedrock
+# instead of the Anthropic API. When enabled, ANTHROPIC_API_KEY is not
+# required and the bot uses Bedrock cross-region inference profile IDs
+# (us.anthropic.*) by default. For other regions use /quick-model with the full
+# cross-region inference profile ID (e.g. eu.anthropic.* or ap.anthropic.*).
+#
+# CLAUDE_CODE_USE_BEDROCK=1
+# AWS_REGION=us-east-1
+#
+# Provide AWS credentials via one of:
+#   - AWS_ACCESS_KEY_ID + AWS_SECRET_ACCESS_KEY (+ AWS_SESSION_TOKEN if STS)
+#   - AWS_PROFILE referencing ~/.aws/credentials (mount dir into container)
+#   - IAM instance role (when running on EC2/ECS/EKS — no creds needed)
+#
+# AWS_ACCESS_KEY_ID=your_access_key_here
+# AWS_SECRET_ACCESS_KEY=your_secret_key_here
+# AWS_SESSION_TOKEN=your_session_token_here  # only for temporary STS credentials
+# AWS_PROFILE=default                        # alternative: use named profile
+
+# ===================================
 # OPTIONAL CONFIGURATION
 # ===================================
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,70 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Runtime & Commands
+
+This project uses **Deno** (not Node.js). All commands use `deno task` or `deno run`.
+
+```bash
+deno task start          # Run the bot
+deno task dev            # Run with hot reload (--watch)
+deno task lint           # Lint with deno lint
+deno task fmt            # Format with deno fmt
+deno task check          # Type-check index.ts and all imports
+```
+
+There is no test suite yet. Type-checking is the primary correctness gate: `deno task check` catches import errors, type mismatches, and structural issues across the full module graph.
+
+## Architecture
+
+The bot is a Discord slash-command interface to the Claude Code SDK (`@anthropic-ai/claude-agent-sdk`).
+
+### Data flow for a Claude query
+
+```
+Discord slash command
+  → core/handler-registry.ts   (route command, build ClaudeModelOptions from settings)
+  → claude/enhanced-client.ts  (create SDK Query, manage session lifecycle)
+  → claude-agent-sdk            (streaming async generator of SDKMessage objects)
+  → claude/message-converter.ts (SDK JSON → ClaudeMessage internal format)
+  → discord/sender.ts          (stream updates to Discord as embeds)
+```
+
+### Module responsibilities
+
+| Directory | Responsibility |
+|-----------|---------------|
+| `claude/` | All Claude SDK integration: query execution, streaming, model discovery, mid-session controls (interrupt, rewind, model swap, permission change), AskUserQuestion, permission prompts, hooks |
+| `core/` | Bot wiring: config loading, factory functions for all handler creation, dependency injection, graceful shutdown |
+| `discord/` | Discord.js wrapper: bot lifecycle, message sending/embedding, pagination, thread-per-session management |
+| `settings/` | Persistent bot settings: model, thinking mode, effort level, system prompt, sandbox mode, etc. |
+| `git/` | `/git` commands and worktree management |
+| `shell/` | `/shell` command with ShellManager |
+| `agent/` | `/agent` command (custom AgentDefinition) |
+| `screenshot/` | `/screenshot` command |
+| `system/`, `util/`, `help/`, `process/` | System info, utilities, help text, crash handling |
+
+### Settings pipeline
+
+`/settings` → `settings/unified-settings.ts` (persist) → `core/handler-registry.ts` `getQueryOptions()` reads all current values → `ClaudeModelOptions` passed to `claude/enhanced-client.ts` on each query.
+
+### Adding a new slash command
+
+1. Define the command (name, description, options) in the feature module's `commands.ts`
+2. Create a handler factory function accepting `HandlerRegistryDeps`
+3. Export command + handler from the module's `index.ts`
+4. Import and wire both into `core/handler-registry.ts` (`getAllCommands()` + `createAllHandlers()`)
+
+### AWS Bedrock backend
+
+Set `CLAUDE_CODE_USE_BEDROCK=1` plus AWS credentials (static keys, profile, or IAM role). When active, the bot uses `us.anthropic.*` cross-region inference profile IDs and `ANTHROPIC_API_KEY` is not required. See `.env.example` for the full variable list.
+
+## Key files
+
+- `index.ts` — entry point; bootstraps Discord client and wires all modules
+- `core/handler-registry.ts` — central hub; builds `ClaudeModelOptions` and routes every command
+- `claude/client.ts` — raw SDK query execution and streaming loop
+- `claude/enhanced-client.ts` — session manager, model discovery, per-session state
+- `settings/unified-settings.ts` — settings state, defaults, disk persistence
+- `discord/session-threads.ts` — thread-per-session lifecycle (create, reuse, close)

--- a/claude/additional-commands.ts
+++ b/claude/additional-commands.ts
@@ -1,5 +1,5 @@
 import { SlashCommandBuilder } from "npm:discord.js@14.14.1";
-import { CLAUDE_MODELS, CLAUDE_TEMPLATES } from "./enhanced-client.ts";
+import { CLAUDE_MODELS, CLAUDE_TEMPLATES, resolveModelId } from "./enhanced-client.ts";
 
 export const additionalClaudeCommands = [
   new SlashCommandBuilder()
@@ -195,10 +195,13 @@ export interface AdditionalClaudeHandlerDeps {
 export function createAdditionalClaudeHandlers(deps: AdditionalClaudeHandlerDeps) {
   const { workDir, sessionManager, crashHandler, sendClaudeMessages, settings } = deps;
 
-  // Helper: merge runtime options (thinking, operation, proxy) into enhanced query options
+  // Helper: merge runtime options into enhanced query options.
+  // Reads from getQueryOptions() so model changes via /quick-model or /settings
+  // are reflected immediately, not just at startup.
   function getRuntimeOpts() {
     const opts = deps.getQueryOptions?.() || {};
     return {
+      model: opts.model ? resolveModelId(opts.model) : resolveModelId(settings.defaultModel),
       permissionMode: opts.permissionMode,
       thinking: opts.thinking,
       effort: opts.effort,
@@ -240,7 +243,6 @@ export function createAdditionalClaudeHandlers(deps: AdditionalClaudeHandlerDeps
           prompt,
           {
             workDir,
-            model: settings.defaultModel,
             includeSystemInfo: false,
             includeGitContext: false,
             ...getRuntimeOpts(),
@@ -302,7 +304,6 @@ export function createAdditionalClaudeHandlers(deps: AdditionalClaudeHandlerDeps
           prompt,
           {
             workDir,
-            model: settings.defaultModel,
             includeSystemInfo: settings.autoIncludeSystemInfo,
             includeGitContext: settings.autoIncludeGitContext,
             contextFiles: contextFilesList,
@@ -365,7 +366,6 @@ export function createAdditionalClaudeHandlers(deps: AdditionalClaudeHandlerDeps
           prompt,
           {
             workDir,
-            model: settings.defaultModel,
             includeSystemInfo: false,
             includeGitContext: settings.autoIncludeGitContext,
             ...getRuntimeOpts(),
@@ -439,7 +439,6 @@ export function createAdditionalClaudeHandlers(deps: AdditionalClaudeHandlerDeps
           prompt,
           {
             workDir,
-            model: settings.defaultModel,
             includeSystemInfo: false,
             includeGitContext: settings.autoIncludeGitContext,
             contextFiles,
@@ -498,7 +497,6 @@ export function createAdditionalClaudeHandlers(deps: AdditionalClaudeHandlerDeps
           prompt,
           {
             workDir,
-            model: settings.defaultModel,
             includeSystemInfo: settings.autoIncludeSystemInfo,
             includeGitContext: settings.autoIncludeGitContext,
             ...getRuntimeOpts(),
@@ -565,7 +563,6 @@ export function createAdditionalClaudeHandlers(deps: AdditionalClaudeHandlerDeps
           prompt,
           {
             workDir,
-            model: settings.defaultModel,
             includeSystemInfo: false,
             includeGitContext: settings.autoIncludeGitContext,
             ...getRuntimeOpts(),
@@ -628,7 +625,6 @@ export function createAdditionalClaudeHandlers(deps: AdditionalClaudeHandlerDeps
           prompt,
           {
             workDir,
-            model: settings.defaultModel,
             includeSystemInfo: false,
             includeGitContext: false,
             ...getRuntimeOpts(),

--- a/claude/client.ts
+++ b/claude/client.ts
@@ -4,6 +4,23 @@ import type { AskUserQuestionInput, AskUserCallback } from "./user-question.ts";
 import type { PermissionRequestCallback } from "./permission-request.ts";
 import * as path from "https://deno.land/std@0.208.0/path/mod.ts";
 
+// Bedrock alias map — only bare user-facing aliases (opus/sonnet/haiku).
+// Full Anthropic IDs (claude-*) and already-valid Bedrock IDs pass through unchanged:
+// full IDs are treated as explicit pins and should not be silently remapped to a
+// different model version. The SDK will return a clear error if they are invalid.
+const BEDROCK_MODEL_MAP: Record<string, string> = {
+  "opus":   "global.anthropic.claude-opus-4-6-v1",
+  "sonnet": "us.anthropic.claude-sonnet-4-5-20250929-v1:0",
+  "haiku":  "us.anthropic.claude-haiku-4-5-20251001-v1:0",
+};
+
+// Resolve a model ID for Bedrock: expands bare aliases to Bedrock profile IDs.
+// No-op for non-Bedrock, already-valid Bedrock IDs, or explicit Anthropic full IDs.
+function resolveBedrockModel(model: string): string {
+  if (Deno.env.get("CLAUDE_CODE_USE_BEDROCK") !== "1") return model;
+  return BEDROCK_MODEL_MAP[model] ?? model;
+}
+
 // Load MCP server configs from .claude/mcp.json
 async function loadMcpServers(workDir: string): Promise<Record<string, McpServerConfig> | undefined> {
   try {
@@ -192,8 +209,17 @@ export async function sendToClaudeCode(
   // Wrap with comprehensive error handling
   const executeWithErrorHandling = async (overrideModel?: string) => {
     try {
-      // Determine which model to use
-      const modelToUse = overrideModel || modelOptions?.model;
+      // Determine which model to use.
+      // On Bedrock, always resolve to a full model ID — bare aliases like "haiku"
+      // are not accepted by the Bedrock endpoint. Also default to "opus" when no
+      // model is configured so the SDK doesn't inherit a broken alias from the
+      // user's global ~/.claude/settings.json (which may pin an ID unavailable
+      // on their Bedrock account).
+      const useBedrock = Deno.env.get("CLAUDE_CODE_USE_BEDROCK") === "1";
+      // On Bedrock, default to "opus" when no model is configured so the SDK
+      // does not inherit a potentially broken alias from ~/.claude/settings.json.
+      const rawModel = overrideModel || modelOptions?.model || (useBedrock ? "opus" : undefined);
+      const modelToUse = rawModel ? resolveBedrockModel(rawModel) : undefined;
       
       // Determine permission mode (defaults to dontAsk for Discord — denies anything not pre-approved)
       const permMode = modelOptions?.permissionMode || "dontAsk";
@@ -206,6 +232,13 @@ export async function sendToClaudeCode(
         // Enable experimental Agent Teams if configured
         ...(modelOptions?.enableAgentTeams && { CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS: '1' }),
       };
+
+      // Remove CLAUDECODE env var — the Claude CLI refuses to start if it detects
+      // it's being launched inside an existing Claude Code session. When the bot
+      // itself runs inside a Claude Code session (e.g. during development), this
+      // variable leaks through Deno.env.toObject() and causes every SDK subprocess
+      // to exit with code 1.
+      delete envVars["CLAUDECODE"];
       
       // Apply extra env vars (proxy settings, etc.)
       if (modelOptions?.extraEnv) {
@@ -239,8 +272,10 @@ export async function sendToClaudeCode(
           ...(cleanedSessionId && !continueMode && { resume: cleanedSessionId }),
           ...(modelToUse && { model: modelToUse }),
           ...(modelOptions?.maxTurns && { maxTurns: modelOptions.maxTurns }),
-          ...(modelOptions?.fallbackModel && { fallbackModel: modelOptions.fallbackModel }),
-          // Native SDK agent support
+          ...(modelOptions?.fallbackModel && { fallbackModel: resolveBedrockModel(modelOptions.fallbackModel) }),
+          // Native SDK agent support — SDK resolves agent model aliases (opus/sonnet/haiku)
+          // internally; agent.model is typed as a constrained union and cannot take full
+          // Bedrock profile IDs, so we leave it for the SDK to handle.
           ...(modelOptions?.agents && { agents: modelOptions.agents }),
           ...(modelOptions?.agent && { agent: modelOptions.agent }),
           // Advanced features: betas, file checkpointing, sandbox, additional dirs, fork
@@ -431,8 +466,12 @@ export async function sendToClaudeCode(
     };
   // deno-lint-ignore no-explicit-any
   } catch (error: any) {
-    // For exit code 1 errors (rate limit), retry with Haiku (cheaper/faster fallback)
-    if (error.message && (error.message.includes('exit code 1') || error.message.includes('exited with code 1'))) {
+    // For exit code 1 errors (rate limit), retry with Haiku (cheaper/faster fallback).
+    // On Bedrock, the SDK does not distinguish rate-limit from model-invalid/auth errors;
+    // retrying could silently substitute a different model tier. Skip retry on Bedrock and
+    // let the original error surface so operators can see the real failure cause.
+    const useBedrock = Deno.env.get("CLAUDE_CODE_USE_BEDROCK") === "1";
+    if (!useBedrock && error.message && (error.message.includes('exit code 1') || error.message.includes('exited with code 1'))) {
       console.log("Rate limit detected, retrying with Haiku (fast fallback)...");
       
       try {

--- a/claude/command.ts
+++ b/claude/command.ts
@@ -32,6 +32,11 @@ export interface SessionThreadCallbacks {
    * Update the session key mapping when the real SDK session ID arrives.
    */
   updateSessionId(oldKey: string, newSessionId: string): void;
+  /**
+   * Register an existing Discord channel/thread as the output target for a session.
+   * Used by free-form cold-starts in threads so /resume and Continue route back there.
+   */
+  registerExistingChannelThread?(channelId: string, sessionId: string): void;
 }
 
 // Discord command definitions
@@ -160,12 +165,15 @@ export function createClaudeHandlers(deps: ClaudeHandlerDeps) {
         deps.getQueryOptions?.()
       );
 
-      // Track session per-channel and globally
-      if (result.sessionId) {
-        deps.setSessionForChannel(channelId, result.sessionId);
+      // Guard all state writes behind ownership — stale aborted runs must not stomp.
+      const stillOwner = deps.getClaudeController() === controller;
+      if (stillOwner) {
+        deps.setClaudeController(null);
+        if (result.sessionId) {
+          deps.setSessionForChannel(channelId, result.sessionId);
+          deps.setClaudeSessionId(result.sessionId);
+        }
       }
-      deps.setClaudeSessionId(result.sessionId);
-      if (deps.getClaudeController() === controller) deps.setClaudeController(null);
 
       return result;
     },
@@ -229,15 +237,19 @@ export function createClaudeHandlers(deps: ClaudeHandlerDeps) {
         deps.getQueryOptions?.()
       );
 
-      deps.setClaudeSessionId(result.sessionId);
-      if (deps.getClaudeController() === controller) deps.setClaudeController(null);
-
-      // Map the thread channel → session so /claude inside the thread auto-continues
-      if (threadSessionKey && result.sessionId && deps.sessionThreads) {
-        deps.sessionThreads.updateSessionId(threadSessionKey, result.sessionId);
-      }
-      if (threadChannelId && result.sessionId) {
-        deps.setSessionForChannel(threadChannelId, result.sessionId);
+      const stillOwner = deps.getClaudeController() === controller;
+      if (stillOwner) {
+        deps.setClaudeController(null);
+        if (result.sessionId) {
+          deps.setClaudeSessionId(result.sessionId);
+          // Map the thread channel → session so /claude inside the thread auto-continues
+          if (threadSessionKey && deps.sessionThreads) {
+            deps.sessionThreads.updateSessionId(threadSessionKey, result.sessionId);
+          }
+          if (threadChannelId) {
+            deps.setSessionForChannel(threadChannelId, result.sessionId);
+          }
+        }
       }
 
       return result;
@@ -311,8 +323,11 @@ export function createClaudeHandlers(deps: ClaudeHandlerDeps) {
         deps.getQueryOptions?.()
       );
 
-      deps.setClaudeSessionId(result.sessionId);
-      if (deps.getClaudeController() === controller) deps.setClaudeController(null);
+      const stillOwner = deps.getClaudeController() === controller;
+      if (stillOwner) {
+        deps.setClaudeController(null);
+        if (result.sessionId) deps.setClaudeSessionId(result.sessionId);
+      }
 
       return result;
     },
@@ -370,6 +385,9 @@ export function createClaudeHandlers(deps: ClaudeHandlerDeps) {
           if (result?.sessionId) {
             deps.setSessionForChannel(channelId, result.sessionId);
             deps.setClaudeSessionId(result.sessionId);
+            // Register the originating channel as the target for this session so
+            // /resume and Continue buttons route back here, not to the main channel.
+            deps.sessionThreads?.registerExistingChannelThread?.(channelId, result.sessionId);
           }
         }
       }

--- a/claude/command.ts
+++ b/claude/command.ts
@@ -2,6 +2,7 @@ import type { ClaudeResponse, ClaudeMessage } from "./types.ts";
 import { sendToClaudeCode, type ClaudeModelOptions } from "./client.ts";
 import { convertToClaudeMessages } from "./message-converter.ts";
 import { SlashCommandBuilder } from "npm:discord.js@14.14.1";
+import type { Message, TextBasedChannel } from "npm:discord.js@14.14.1";
 
 // Callback that creates (or retrieves) a session thread and returns a
 // sender function bound to that thread.
@@ -90,6 +91,8 @@ export interface ClaudeHandlerDeps {
   getQueryOptions?: () => ClaudeModelOptions;
   /** Thread-per-session callbacks (optional — when absent, falls back to main channel) */
   sessionThreads?: SessionThreadCallbacks;
+  /** Create a sender bound to an arbitrary channel/thread (for free-form message routing) */
+  createSenderForChannel?: (channel: TextBasedChannel) => (messages: ClaudeMessage[]) => Promise<void>;
 }
 
 export function createClaudeHandlers(deps: ClaudeHandlerDeps) {
@@ -162,7 +165,7 @@ export function createClaudeHandlers(deps: ClaudeHandlerDeps) {
         deps.setSessionForChannel(channelId, result.sessionId);
       }
       deps.setClaudeSessionId(result.sessionId);
-      deps.setClaudeController(null);
+      if (deps.getClaudeController() === controller) deps.setClaudeController(null);
 
       return result;
     },
@@ -227,7 +230,7 @@ export function createClaudeHandlers(deps: ClaudeHandlerDeps) {
       );
 
       deps.setClaudeSessionId(result.sessionId);
-      deps.setClaudeController(null);
+      if (deps.getClaudeController() === controller) deps.setClaudeController(null);
 
       // Map the thread channel → session so /claude inside the thread auto-continues
       if (threadSessionKey && result.sessionId && deps.sessionThreads) {
@@ -309,9 +312,69 @@ export function createClaudeHandlers(deps: ClaudeHandlerDeps) {
       );
 
       deps.setClaudeSessionId(result.sessionId);
-      deps.setClaudeController(null);
+      if (deps.getClaudeController() === controller) deps.setClaudeController(null);
 
       return result;
+    },
+
+    async onFreeFormMessage(message: Message): Promise<void> {
+      const channelId = message.channelId;
+      const prompt = message.content;
+
+      // Read existing session BEFORE installing new controller — synchronous, no interleaving.
+      const existingSessionId = deps.getSessionForChannel(channelId);
+
+      const prior = deps.getClaudeController();
+      if (prior) prior.abort();
+      const controller = new AbortController();
+      deps.setClaudeController(controller);
+
+      // Sender: use registered thread sender if the session has one,
+      // else bind directly to message.channel (fixes cold-start-in-thread routing).
+      let activeSender: (messages: ClaudeMessage[]) => Promise<void> = sendClaudeMessages;
+      if (existingSessionId && deps.sessionThreads) {
+        const existing = await deps.sessionThreads
+          .getThreadSender(existingSessionId)
+          .catch(() => undefined);
+        if (existing) activeSender = existing.sender;
+      }
+      if (activeSender === sendClaudeMessages && deps.createSenderForChannel) {
+        activeSender = deps.createSenderForChannel(message.channel as TextBasedChannel);
+      }
+
+      message.react("👀").catch(() => {});
+
+      let result: ClaudeResponse | undefined;
+      try {
+        result = await sendToClaudeCode(
+          workDir,
+          prompt,
+          controller,
+          existingSessionId,
+          undefined,
+          (jsonData) => {
+            const claudeMessages = convertToClaudeMessages(jsonData);
+            if (claudeMessages.length > 0) activeSender(claudeMessages).catch(() => {});
+          },
+          false,
+          deps.getQueryOptions?.()
+        );
+      } catch (err) {
+        console.error("[FreeForm] Claude run failed:", err);
+        message.react("❌").catch(() => {});
+      } finally {
+        // Compare-and-clear — only if we still own the controller slot.
+        if (deps.getClaudeController() === controller) {
+          deps.setClaudeController(null);
+        }
+        // Persist sessionId only if we cleared (i.e. we still owned the slot).
+        if (result?.sessionId && deps.getClaudeController() === null) {
+          deps.setSessionForChannel(channelId, result.sessionId);
+          if (!deps.getClaudeSessionId()) {
+            deps.setClaudeSessionId(result.sessionId);
+          }
+        }
+      }
     },
 
     // deno-lint-ignore no-explicit-any

--- a/claude/command.ts
+++ b/claude/command.ts
@@ -363,14 +363,12 @@ export function createClaudeHandlers(deps: ClaudeHandlerDeps) {
         console.error("[FreeForm] Claude run failed:", err);
         message.react("❌").catch(() => {});
       } finally {
-        // Compare-and-clear — only if we still own the controller slot.
-        if (deps.getClaudeController() === controller) {
+        // Capture ownership once — use it for both the clear and the session write.
+        const stillOwner = deps.getClaudeController() === controller;
+        if (stillOwner) {
           deps.setClaudeController(null);
-        }
-        // Persist sessionId only if we cleared (i.e. we still owned the slot).
-        if (result?.sessionId && deps.getClaudeController() === null) {
-          deps.setSessionForChannel(channelId, result.sessionId);
-          if (!deps.getClaudeSessionId()) {
+          if (result?.sessionId) {
+            deps.setSessionForChannel(channelId, result.sessionId);
             deps.setClaudeSessionId(result.sessionId);
           }
         }

--- a/claude/enhanced-client.ts
+++ b/claude/enhanced-client.ts
@@ -445,8 +445,8 @@ export let CLAUDE_MODELS: Record<string, ModelInfo> = {
 export const BEDROCK_MODELS: Record<string, ModelInfo> = {
   // === Aliases ===
   'opus': {
-    name: 'Claude Opus (Latest)',
-    description: 'Most powerful model — Bedrock global inference',
+    name: 'Claude Opus 4.6 (Bedrock)',
+    description: 'Pinned: global.anthropic.claude-opus-4-6-v1 — update alias for newer versions',
     contextWindow: 200000,
     recommended: true,
     supportsThinking: true,
@@ -454,8 +454,8 @@ export const BEDROCK_MODELS: Record<string, ModelInfo> = {
     aliasFor: 'global.anthropic.claude-opus-4-6-v1'
   },
   'sonnet': {
-    name: 'Claude Sonnet (Latest)',
-    description: 'High-performance model — Bedrock cross-region inference',
+    name: 'Claude Sonnet 4.5 (Bedrock)',
+    description: 'Pinned: us.anthropic.claude-sonnet-4-5-20250929-v1:0 — update alias for newer versions',
     contextWindow: 200000,
     recommended: true,
     supportsThinking: true,
@@ -463,8 +463,8 @@ export const BEDROCK_MODELS: Record<string, ModelInfo> = {
     aliasFor: 'us.anthropic.claude-sonnet-4-5-20250929-v1:0'
   },
   'haiku': {
-    name: 'Claude Haiku (Latest)',
-    description: 'Fast model — Bedrock cross-region inference',
+    name: 'Claude Haiku 4.5 (Bedrock)',
+    description: 'Pinned: us.anthropic.claude-haiku-4-5-20251001-v1:0 — update alias for newer versions',
     contextWindow: 200000,
     recommended: true,
     supportsThinking: false,

--- a/claude/enhanced-client.ts
+++ b/claude/enhanced-client.ts
@@ -440,6 +440,77 @@ export let CLAUDE_MODELS: Record<string, ModelInfo> = {
   }
 };
 
+// Bedrock cross-region inference profile IDs (us.* prefix by default).
+// Users in other regions can override via /quick-model with eu.* or ap.* IDs.
+export const BEDROCK_MODELS: Record<string, ModelInfo> = {
+  // === Aliases ===
+  'opus': {
+    name: 'Claude Opus (Latest)',
+    description: 'Most powerful model — Bedrock global inference',
+    contextWindow: 200000,
+    recommended: true,
+    supportsThinking: true,
+    tier: 'flagship',
+    aliasFor: 'global.anthropic.claude-opus-4-6-v1'
+  },
+  'sonnet': {
+    name: 'Claude Sonnet (Latest)',
+    description: 'High-performance model — Bedrock cross-region inference',
+    contextWindow: 200000,
+    recommended: true,
+    supportsThinking: true,
+    tier: 'balanced',
+    aliasFor: 'us.anthropic.claude-sonnet-4-5-20250929-v1:0'
+  },
+  'haiku': {
+    name: 'Claude Haiku (Latest)',
+    description: 'Fast model — Bedrock cross-region inference',
+    contextWindow: 200000,
+    recommended: true,
+    supportsThinking: false,
+    tier: 'fast',
+    aliasFor: 'us.anthropic.claude-haiku-4-5-20251001-v1:0'
+  },
+
+  // === Opus Family ===
+  'global.anthropic.claude-opus-4-6-v1': {
+    name: 'Claude Opus 4.6 (Bedrock)',
+    description: 'Latest flagship — standard context, global Bedrock inference',
+    contextWindow: 200000,
+    recommended: true,
+    supportsThinking: true,
+    tier: 'flagship'
+  },
+
+  // === Sonnet Family ===
+  'us.anthropic.claude-sonnet-4-5-20250929-v1:0': {
+    name: 'Claude Sonnet 4.5 (Bedrock)',
+    description: 'Latest Sonnet — balanced speed/cost, Bedrock inference',
+    contextWindow: 200000,
+    recommended: true,
+    supportsThinking: true,
+    tier: 'balanced'
+  },
+  'us.anthropic.claude-sonnet-4-20250514-v1:0': {
+    name: 'Claude Sonnet 4 (Bedrock)',
+    description: 'Previous Sonnet',
+    contextWindow: 200000,
+    recommended: false,
+    supportsThinking: true,
+    tier: 'balanced'
+  },
+
+  // === Haiku Family ===
+  'us.anthropic.claude-haiku-4-5-20251001-v1:0': {
+    name: 'Claude Haiku 4.5 (Bedrock)',
+    description: 'Fast and efficient, Bedrock inference',
+    contextWindow: 200000,
+    recommended: false,
+    supportsThinking: false,
+    tier: 'fast'
+  },
+};
+
 // Resolve model alias to full model ID
 // If the input is an alias, returns the resolved ID; otherwise returns the input unchanged
 export function resolveModelId(modelInput: string): string {
@@ -465,11 +536,16 @@ export function isValidModel(modelInput: string): boolean {
 
 /**
  * Initialize dynamic model fetching.
- * Call once at startup. If ANTHROPIC_API_KEY is set, fetches models
- * from the Anthropic API and refreshes every hour.
- * Falls back to the hardcoded defaults above if unavailable.
+ * When CLAUDE_CODE_USE_BEDROCK=1, switches to BEDROCK_MODELS immediately and
+ * skips the Anthropic API refresh loop. Otherwise fetches from Anthropic API
+ * hourly and falls back to hardcoded defaults if unavailable.
  */
 export function initModels(): void {
+  if (Deno.env.get("CLAUDE_CODE_USE_BEDROCK") === "1") {
+    CLAUDE_MODELS = { ...BEDROCK_MODELS };
+    console.log(`[Models] Bedrock backend — using ${Object.keys(BEDROCK_MODELS).length} Bedrock model IDs`);
+    return;
+  }
   startModelRefresh((newModels) => {
     CLAUDE_MODELS = newModels;
     console.log(`[Models] Dynamically updated to ${Object.keys(CLAUDE_MODELS).length} models from Anthropic API`);

--- a/claude/enhanced-commands.ts
+++ b/claude/enhanced-commands.ts
@@ -1,5 +1,5 @@
 import { SlashCommandBuilder } from "npm:discord.js@14.14.1";
-import { CLAUDE_MODELS, CLAUDE_TEMPLATES, type ModelInfo } from "./enhanced-client.ts";
+import { CLAUDE_MODELS, CLAUDE_TEMPLATES, resolveModelId, type ModelInfo } from "./enhanced-client.ts";
 
 export const enhancedClaudeCommands = [
   new SlashCommandBuilder()
@@ -13,12 +13,7 @@ export const enhancedClaudeCommands = [
       option.setName('model')
         .setDescription('Claude model to use')
         .setRequired(false)
-        .addChoices(
-          ...Object.entries(CLAUDE_MODELS).map(([value, model]) => ({
-            name: model.name,
-            value: value
-          }))
-        ))
+        .setAutocomplete(true))
     .addStringOption(option =>
       option.setName('template')
         .setDescription('Use a predefined template')
@@ -164,7 +159,7 @@ export function createEnhancedClaudeHandlers(deps: EnhancedClaudeHandlerDeps) {
           enhancedPrompt,
           {
             workDir,
-            model: model || runtimeOpts.model,
+            model: model ? resolveModelId(model) : runtimeOpts.model,
             includeSystemInfo: !!includeSystemInfo,
             includeGitContext: !!includeGitContext,
             contextFiles: contextFilesList,

--- a/claude/info-commands.ts
+++ b/claude/info-commands.ts
@@ -116,7 +116,7 @@ export function createInfoCommandHandlers(deps: InfoCommandHandlerDeps) {
           }
           if (!account) {
             // Open ephemeral query for info
-            const info = await fetchClaudeInfo(workDir);
+            const info = await fetchClaudeInfo(workDir, undefined, deps.getQueryOptions?.()?.model);
             if (info) {
               account = info.account;
               // If showing all, we got everything in one call
@@ -151,7 +151,7 @@ export function createInfoCommandHandlers(deps: InfoCommandHandlerDeps) {
             models = await getSupportedModels();
           }
           if (!models) {
-            const info = await fetchClaudeInfo(workDir);
+            const info = await fetchClaudeInfo(workDir, undefined, deps.getQueryOptions?.()?.model);
             models = info?.models;
           }
           if (models && models.length > 0) {

--- a/claude/model-fetcher.ts
+++ b/claude/model-fetcher.ts
@@ -133,6 +133,7 @@ function buildAliases(models: Record<string, ModelInfo>, apiModels: AnthropicMod
  * Returns null if no API key is set or the request fails.
  */
 async function fetchFromAPI(): Promise<AnthropicModelEntry[] | null> {
+  if (Deno.env.get("CLAUDE_CODE_USE_BEDROCK") === "1") return null;
   const apiKey = Deno.env.get("ANTHROPIC_API_KEY");
   if (!apiKey) {
     return null;
@@ -373,6 +374,11 @@ function extractDateFromId(id: string): string {
  * Strategy: API key > CLI binary parsing > null (use hardcoded defaults).
  */
 export async function fetchModels(): Promise<Record<string, ModelInfo> | null> {
+  // On Bedrock, dynamic model discovery from the Anthropic API or CLI binary
+  // would overwrite BEDROCK_MODELS with Anthropic API IDs. Return null so the
+  // caller keeps using BEDROCK_MODELS (set by initModels() in enhanced-client.ts).
+  if (Deno.env.get("CLAUDE_CODE_USE_BEDROCK") === "1") return null;
+
   const now = Date.now();
 
   // Return cached if still fresh

--- a/claude/query-manager.ts
+++ b/claude/query-manager.ts
@@ -109,16 +109,29 @@ export async function interruptActiveQuery(): Promise<boolean> {
 
 /**
  * Change the model on the active query mid-session.
+ * On Bedrock, bare aliases and Anthropic full IDs are mapped to Bedrock profile IDs.
  */
 export async function setActiveModel(model?: string): Promise<boolean> {
   if (!activeQuery) return false;
   try {
-    await activeQuery.setModel(model);
+    const resolved = model && Deno.env.get("CLAUDE_CODE_USE_BEDROCK") === "1"
+      ? (BEDROCK_MID_SESSION_MAP[model] ?? model)
+      : model;
+    await activeQuery.setModel(resolved);
     return true;
   } catch {
     return false;
   }
 }
+
+// Bedrock alias map for mid-session switches — only bare aliases, same policy as
+// BEDROCK_MODEL_MAP in client.ts. Full Anthropic IDs pass through unchanged.
+// Inlined to avoid circular imports (client.ts ↔ query-manager.ts).
+const BEDROCK_MID_SESSION_MAP: Record<string, string> = {
+  "opus":   "global.anthropic.claude-opus-4-6-v1",
+  "sonnet": "us.anthropic.claude-sonnet-4-5-20250929-v1:0",
+  "haiku":  "us.anthropic.claude-haiku-4-5-20251001-v1:0",
+};
 
 /**
  * Change the permission mode on the active query mid-session.
@@ -283,9 +296,15 @@ export async function setMcpServersActive(servers: Record<string, McpServerConfi
  * @param workDir - Working directory for the session
  * @param envVars - Environment variables (must include ANTHROPIC_API_KEY)
  */
-export async function fetchClaudeInfo(workDir: string, envVars?: Record<string, string>): Promise<ClaudeInitInfo | null> {
+export async function fetchClaudeInfo(workDir: string, envVars?: Record<string, string>, model?: string): Promise<ClaudeInitInfo | null> {
   let infoQuery: Query | null = null;
   try {
+    // Determine the model to use. On Bedrock, prefer the caller-supplied model
+    // (from getQueryOptions), then fall back to opus. This avoids inheriting a
+    // potentially invalid Anthropic API model from ~/.claude/settings.json.
+    const infoModel = model
+      ?? (Deno.env.get("CLAUDE_CODE_USE_BEDROCK") === "1" ? BEDROCK_MID_SESSION_MAP["opus"] : undefined);
+
     // Create a minimal query — it will start the CLI subprocess
     infoQuery = claudeQuery({
       prompt: "Say 'info' and nothing else.",
@@ -296,9 +315,13 @@ export async function fetchClaudeInfo(workDir: string, envVars?: Record<string, 
         thinking: { type: 'disabled' },
         effort: 'low',
         persistSession: false,
-        env: envVars ?? Object.fromEntries(
-          Object.entries(Deno.env.toObject())
-        ),
+        ...(infoModel && { model: infoModel }),
+        env: (() => {
+          const env = envVars ?? Object.fromEntries(Object.entries(Deno.env.toObject()));
+          // Prevent "cannot be launched inside another Claude Code session" error
+          delete env["CLAUDECODE"];
+          return env;
+        })(),
       },
     });
 

--- a/core/handler-registry.ts
+++ b/core/handler-registry.ts
@@ -27,7 +27,7 @@ import { helpCommand, createHelpHandlers } from "../help/index.ts";
 import { agentCommand, createAgentHandlers } from "../agent/index.ts";
 import { screenshotCommands, createScreenshotHandlers } from "../screenshot/index.ts";
 import { infoCommands, createInfoCommandHandlers } from "../claude/index.ts";
-import { cleanSessionId, ClaudeSessionManager } from "../claude/index.ts";
+import { cleanSessionId, ClaudeSessionManager, resolveModelId } from "../claude/index.ts";
 import type { SessionThreadCallbacks } from "../claude/index.ts";
 import type { ClaudeModelOptions } from "../claude/index.ts";
 import type { AskUserCallback } from "../claude/index.ts";
@@ -393,9 +393,12 @@ export function createAllHandlers(
     const s = settings.getSettings().unified;
     const opts: ClaudeModelOptions = {};
 
-    // Model — fast mode is handled by CLI via .claude/settings.local.json (not a model switch)
+    // Model — fast mode is handled by CLI via .claude/settings.local.json (not a model switch).
+    // resolveModelId expands aliases (opus/sonnet/haiku) to their full model IDs.
+    // On Bedrock, CLAUDE_MODELS is swapped to BEDROCK_MODELS so aliases resolve to
+    // Bedrock profile IDs (e.g. opus → global.anthropic.claude-opus-4-6-v1[1m]).
     if (s.defaultModel) {
-      opts.model = s.defaultModel;
+      opts.model = resolveModelId(s.defaultModel);
     }
 
     // Operation mode → SDK permissionMode

--- a/core/handler-registry.ts
+++ b/core/handler-registry.ts
@@ -12,6 +12,7 @@ import type {
 } from "../discord/index.ts";
 
 import type { ClaudeMessage } from "../claude/index.ts";
+import type { TextBasedChannel } from "npm:discord.js@14.14.1";
 
 // Import command definitions
 import { claudeCommands, createClaudeHandlers } from "../claude/index.ts";
@@ -166,6 +167,8 @@ export interface HandlerRegistryDeps {
   crashHandler: ProcessCrashHandler;
   /** Health monitor instance */
   healthMonitor: ProcessHealthMonitor;
+  /** Factory that creates a sender bound to any channel/thread */
+  createSenderForChannel?: (channel: TextBasedChannel) => (messages: ClaudeMessage[]) => Promise<void>;
   /** Claude session manager instance */
   claudeSessionManager: ClaudeSessionManager;
   /** Function to send Claude messages */
@@ -530,6 +533,7 @@ export function createAllHandlers(
     sendClaudeMessages,
     getQueryOptions,
     sessionThreads: deps.sessionThreads,
+    createSenderForChannel: deps.createSenderForChannel,
   });
 
   const gitHandlers = createGitHandlers({

--- a/discord/bot.ts
+++ b/discord/bot.ts
@@ -20,6 +20,7 @@ import { sanitizeChannelName } from "./utils.ts";
 import { handlePaginationInteraction } from "./pagination.ts";
 import { checkCommandPermission } from "../core/rbac.ts";
 import { SETTINGS_ACTIONS, SETTINGS_VALUES } from "../settings/unified-settings.ts";
+import { CLAUDE_MODELS } from "../claude/enhanced-client.ts";
 import { BOT_VERSION } from "../util/version-check.ts";
 import type {
   BotConfig,
@@ -306,19 +307,41 @@ export async function createDiscordBot(
 
   // Autocomplete handler for /settings action & value fields
   async function handleAutocomplete(interaction: AutocompleteInteraction) {
+    const focused = interaction.options.getFocused(true);
+    const typed = focused.value.toLowerCase();
+
+    // /claude-enhanced model autocomplete — served from live CLAUDE_MODELS so
+    // Bedrock deployments see Bedrock profile IDs after initModels() swaps the map.
+    if (interaction.commandName === 'claude-enhanced' && focused.name === 'model') {
+      const choices = Object.entries(CLAUDE_MODELS)
+        .map(([value, model]) => ({ name: model.name, value }))
+        .filter(c => c.name.toLowerCase().includes(typed) || c.value.toLowerCase().includes(typed))
+        .slice(0, 25);
+      await interaction.respond(choices);
+      return;
+    }
+
     if (interaction.commandName !== 'settings') return;
 
-    const focused = interaction.options.getFocused(true);
     const category = interaction.options.getString('category') ?? '';
     const action = interaction.options.getString('action') ?? '';
-    const typed = focused.value.toLowerCase();
 
     let choices: { name: string; value: string }[] = [];
 
     if (focused.name === 'action') {
       choices = SETTINGS_ACTIONS[category] ?? [];
     } else if (focused.name === 'value') {
-      choices = SETTINGS_VALUES[action] ?? [];
+      // For set-model: serve the live CLAUDE_MODELS map so Bedrock deployments
+      // see Bedrock profile IDs after initModels() swaps the map, not the
+      // frozen Anthropic IDs captured at module-import time in SETTINGS_VALUES.
+      if (action === 'set-model') {
+        choices = Object.entries(CLAUDE_MODELS).map(([key, model]) => ({
+          name: `${key} — ${model.name}`,
+          value: key,
+        }));
+      } else {
+        choices = SETTINGS_VALUES[action] ?? [];
+      }
     }
 
     // Filter by what the user has typed so far

--- a/discord/bot.ts
+++ b/discord/bot.ts
@@ -642,6 +642,23 @@ export async function createDiscordBot(
     console.log(`[Monitor] Watching channel ${channelId} for messages from ${botIds.join(', ')}`);
   }
 
+  // Free-form message handling — plain text in the bot's channel/threads triggers Claude
+  if (dependencies.onFreeFormMessage) {
+    client.on(Events.MessageCreate, async (message: Message) => {
+      if (message.author.bot) return;
+      if (message.webhookId) return;
+      if (!message.content?.trim()) return;
+      if (!isOurChannel(message.channelId)) return;
+      try {
+        await dependencies.onFreeFormMessage!(message);
+      } catch (err) {
+        console.error("[FreeForm] Listener error:", err);
+        message.react("❌").catch(() => {});
+      }
+    });
+    console.log("[FreeForm] Free-form message handling enabled");
+  }
+
   // Login
   await client.login(discordToken);
 

--- a/discord/types.ts
+++ b/discord/types.ts
@@ -1,5 +1,5 @@
 // Discord module types
-import type { TextChannel } from "npm:discord.js@14.14.1";
+import type { TextChannel, Message } from "npm:discord.js@14.14.1";
 import type { BotSettings } from "../types/shared.ts";
 
 export interface EmbedData {
@@ -127,4 +127,6 @@ export interface BotDependencies {
   onContinueSession?: (ctx: InteractionContext) => Promise<void>;
   /** Optional channel monitoring config for auto-responding to messages */
   monitorConfig?: MonitorConfig;
+  /** Optional handler for free-form text messages in the bot's channel/threads */
+  onFreeFormMessage?: (message: Message) => Promise<void>;
 }

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,9 +1,11 @@
 # Claude Code Discord Bot - Docker Compose Configuration
 # Quick start: docker compose up -d
 #
-# IMPORTANT: The ANTHROPIC_API_KEY in your .env file is required for Docker.
-# The Claude CLI inside the container uses it to authenticate with Anthropic.
-# (Unlike native installs, you cannot run `claude /login` inside the container.)
+# Authentication (choose one):
+#   Option A: Set ANTHROPIC_API_KEY in your .env file (Anthropic API)
+#   Option B: Run `docker exec -it claude-code-discord claude /login` after starting
+#             (credentials persist in the claude-config volume)
+#   Option C: Set CLAUDE_CODE_USE_BEDROCK=1 + AWS credentials in your .env file (AWS Bedrock)
 #
 # To use the pre-built image from GitHub Container Registry (recommended):
 #   1. Comment out the 'build' section below
@@ -29,7 +31,14 @@ services:
     environment:
       - DISCORD_TOKEN=${DISCORD_TOKEN}
       - APPLICATION_ID=${APPLICATION_ID}
-      - ANTHROPIC_API_KEY=${ANTHROPIC_API_KEY}
+      - ANTHROPIC_API_KEY=${ANTHROPIC_API_KEY:-}
+      # AWS Bedrock backend (set CLAUDE_CODE_USE_BEDROCK=1 in .env to enable)
+      - CLAUDE_CODE_USE_BEDROCK=${CLAUDE_CODE_USE_BEDROCK:-}
+      - AWS_REGION=${AWS_REGION:-}
+      - AWS_ACCESS_KEY_ID=${AWS_ACCESS_KEY_ID:-}
+      - AWS_SECRET_ACCESS_KEY=${AWS_SECRET_ACCESS_KEY:-}
+      - AWS_SESSION_TOKEN=${AWS_SESSION_TOKEN:-}
+      - AWS_PROFILE=${AWS_PROFILE:-}
       - WORK_DIR=${WORK_DIR:-/app/workspace}
       - USER_ID=${USER_ID:-}
       - CATEGORY_NAME=${CATEGORY_NAME:-claude-code}
@@ -44,6 +53,8 @@ services:
       # Optional: Mount your local workspace for Claude to work on
       # Uncomment and modify path as needed:
       # - /path/to/your/project:/app/workspace
+      # Optional: Mount AWS credentials for Bedrock when using AWS_PROFILE
+      # - ${HOME}/.aws:/home/claude/.aws:ro
 
     # Resource limits (adjust based on your needs)
     deploy:

--- a/index.ts
+++ b/index.ts
@@ -103,7 +103,8 @@ export async function createClaudeCodeBot(config: BotConfig) {
 
   const { shellManager, worktreeBotManager, crashHandler, healthMonitor, claudeSessionManager } = managers;
 
-  // Initialize dynamic model fetching (uses ANTHROPIC_API_KEY if available)
+  const useBedrock = Deno.env.get("CLAUDE_CODE_USE_BEDROCK") === "1";
+  console.log(`[Backend] LLM provider: ${useBedrock ? `AWS Bedrock (region: ${Deno.env.get("AWS_REGION") ?? "default"})` : "Anthropic API"}`);
   initModels();
 
   // Setup periodic cleanup tasks

--- a/index.ts
+++ b/index.ts
@@ -184,6 +184,16 @@ export async function createClaudeCodeBot(config: BotConfig) {
     updateSessionId(oldKey: string, newSessionId: string) {
       sessionThreadManager.updateSessionId(oldKey, newSessionId);
     },
+
+    registerExistingChannelThread(channelId: string, sessionId: string) {
+      // Register an existing Discord thread as the routing target for this session
+      // so /resume and Continue buttons send output there, not to the main channel.
+      // Only register actual threads (not the main TextChannel) to satisfy ThreadChannel typing.
+      const channel = bot?.client.channels.cache.get(channelId);
+      if (channel?.isThread()) {
+        sessionThreadManager.setThreadChannel(sessionId, channel);
+      }
+    },
   };
 
   // Late-bound AskUserQuestion handler — set after bot is created.

--- a/index.ts
+++ b/index.ts
@@ -19,7 +19,7 @@ import {
   type MessageContent,
   SessionThreadManager,
 } from "./discord/index.ts";
-import type { TextChannel } from "npm:discord.js@14.14.1";
+import type { Message, TextBasedChannel, TextChannel } from "npm:discord.js@14.14.1";
 
 import { getGitInfo } from "./git/index.ts";
 import { createClaudeSender, expandableContent, sendToClaudeCode, convertToClaudeMessages, type DiscordSender, type ClaudeMessage, type SessionThreadCallbacks } from "./claude/index.ts";
@@ -247,6 +247,8 @@ export async function createClaudeCodeBot(config: BotConfig) {
         }
       },
       sessionThreads: sessionThreadCallbacks,
+      createSenderForChannel: (channel: TextBasedChannel) =>
+        createClaudeSender(createChannelSenderAdapter(channel)),
     },
     {
       getController: () => claudeController,
@@ -286,6 +288,9 @@ export async function createClaudeCodeBot(config: BotConfig) {
   const monitorBotIds = Deno.env.get("MONITOR_BOT_IDS")?.split(",").map(s => s.trim()).filter(Boolean);
 
   // Create dependencies object for Discord bot
+  const onFreeFormMessage = (message: Message) =>
+    allHandlers.claude.onFreeFormMessage(message);
+
   const dependencies: BotDependencies = {
     commands: getAllCommands(),
     cleanSessionId,
@@ -293,6 +298,7 @@ export async function createClaudeCodeBot(config: BotConfig) {
     onContinueSession: async (ctx) => {
       await allHandlers.claude.onContinue(ctx);
     },
+    onFreeFormMessage,
     ...(monitorChannelId && monitorBotIds?.length && {
       monitorConfig: {
         channelId: monitorChannelId,

--- a/settings/handlers.ts
+++ b/settings/handlers.ts
@@ -274,7 +274,11 @@ export function createAdvancedSettingsHandlers(deps: SettingsHandlerDeps) {
     async onQuickModel(ctx: any, model: string) {
       try {
         const selectedModel = CLAUDE_MODELS[model as keyof typeof CLAUDE_MODELS];
-        if (!selectedModel) {
+        // Also accept any Bedrock cross-region inference profile ID (any lowercase geo prefix
+        // followed by .anthropic.) — e.g. us.*, eu.*, ap.*, au.*, jp.*, global.*
+        // The SDK validates the exact profile ID at runtime; we just avoid false rejections.
+        const isBedrockProfile = /^[a-z]+\.anthropic\./i.test(model);
+        if (!selectedModel && !isBedrockProfile) {
           const modelList = Object.entries(CLAUDE_MODELS)
             .map(([key, m]) => `\`${key}\` — ${m.name}${m.recommended ? ' ⭐' : ''}`)
             .join('\n');
@@ -294,15 +298,16 @@ export function createAdvancedSettingsHandlers(deps: SettingsHandlerDeps) {
 
         updateSettings({ defaultModel: model });
 
+        const modelName = selectedModel?.name ?? model;
         await ctx.reply({
           embeds: [{
             color: 0x00ff00,
             title: '🚀 Model Switched',
-            description: `Now using **${selectedModel.name}** for Claude conversations`,
+            description: `Now using **${modelName}** for Claude conversations`,
             fields: [
               { name: 'Model ID', value: `\`${model}\``, inline: true },
-              { name: 'Context Window', value: selectedModel.contextWindow.toLocaleString() + ' tokens', inline: true },
-              { name: 'Thinking Mode', value: selectedModel.supportsThinking ? 'Enabled' : 'Disabled', inline: true }
+              { name: 'Context Window', value: selectedModel ? selectedModel.contextWindow.toLocaleString() + ' tokens' : 'varies', inline: true },
+              { name: 'Thinking Mode', value: selectedModel ? (selectedModel.supportsThinking ? 'Enabled' : 'Disabled') : 'varies', inline: true }
             ],
             footer: { text: 'This applies to all new conversations' },
             timestamp: true


### PR DESCRIPTION
## Summary

- Plain text in the bot's main channel or any child thread now triggers Claude — no slash command needed
- Bot reacts with 👀, streams output back to the channel/thread the user typed in, and persists the session for follow-up messages
- Apply compare-and-clear controller guard to `onClaude`, `onClaudeThread`, and `onContinue` as a bonus correctness fix

## Changes

| File | Change |
|---|---|
| `claude/command.ts` | New `onFreeFormMessage` handler; compare-and-clear applied to 3 existing handlers |
| `core/handler-registry.ts` | New `createSenderForChannel` dep field + forward |
| `discord/bot.ts` | New `MessageCreate` listener (filters: bot, webhook, empty, out-of-scope) |
| `discord/types.ts` | `onFreeFormMessage?` added to `BotDependencies` |
| `index.ts` | Wire-up: `createSenderForChannel` factory, `onFreeFormMessage` callback |

## Design notes

- Output routing: sender is bound to `message.channel` for cold starts, so a free-form message in any child thread replies **in that thread** (not main channel)
- Session continuity: reads `getSessionForChannel(channelId)` before installing the controller — no await between the two, so no interleaving
- Concurrent messages: each new message aborts the prior controller via compare-and-clear; only the latest run persists its session

## Known limitations (pre-existing, not introduced here)

- `setClaudeSessionId` / `setActiveQuery` stale-clear races exist in the original `/claude` handler and are inherited. Full fix tracked as follow-up `ClaudeRunManager` refactor.
- Free-form during an in-flight `/claude-thread` starts a new session (placeholder window gap)
- Bot restart clears all per-channel session bindings (in-memory only)

## Test plan

- [ ] Cold main-channel message → 👀 reaction, reply in main
- [ ] Follow-up message in main → resumes same session
- [ ] Cold message in manually-created child thread → reply in thread (not main)
- [ ] `/claude-thread` completes → free-form follow-up in that thread → continues in thread
- [ ] Message in another Discord channel → bot ignores it
- [ ] Webhook post in main → bot ignores it
- [ ] Image-only message (no text) → bot ignores it

🤖 Generated with [Claude Code](https://claude.ai/claude-code)